### PR TITLE
fix: invert condition to show login or copy modal

### DIFF
--- a/src/components/collection/CopyButton.js
+++ b/src/components/collection/CopyButton.js
@@ -48,8 +48,8 @@ const CopyButton = ({ id }) => {
   }
 
   const onClick = () => {
-    // display sign in modal if the user is not signed in
-    if (!user?.id) {
+    // show item tree, otherwise display sign in modal if the user is not signed in
+    if (user?.id) {
       setShowTreeModal(true);
     } else {
       openLoginModal(true);


### PR DESCRIPTION
The condition to show either the copy or login modal is inverted:
- the item tree should be shown if the user is logged in, otherwise the login modal should be displayed
