### PR TITLE
feat: add dynamic tree viewer for copy modal

### DIFF
--- a/src/components/collection/CopyButton.js
+++ b/src/components/collection/CopyButton.js
@@ -25,20 +25,20 @@ const CopyButton = ({ id }) => {
     MUTATION_KEYS.COPY_PUBLIC_ITEM,
   );
 
-  const { setOpen: openLoginModal, open: showLoginModal } =
+  const { setOpen: setShowLoginModal, open: showLoginModal } =
     useContext(LoginModalContext);
 
   useEffect(() => {
     // if the user signs in while the login modal is open
     // switch to copy modal
     if (showLoginModal && !user?.id) {
-      openLoginModal(false);
+      setShowLoginModal(false);
       setShowTreeModal(true);
     }
     // if user signs out while copying
     // show login modal instead
     else if (showTreeModal && !user?.id) {
-      openLoginModal(true);
+      setShowLoginModal(true);
       setShowTreeModal(false);
     }
   }, [user]);
@@ -52,15 +52,15 @@ const CopyButton = ({ id }) => {
     if (user?.id) {
       setShowTreeModal(true);
     } else {
-      openLoginModal(true);
+      setShowLoginModal(true);
     }
   };
 
   // todo: set notifier for copy
-  const copy = ({ id: toSpace }) => {
+  const copy = ({ to }) => {
     // remove loading icon on callback
     // do not set parent if it is root
-    copyItem({ id, to: toSpace === ROOT_ID ? undefined : toSpace });
+    copyItem({ id, to: to === ROOT_ID ? undefined : to });
   };
 
   const renderButton = () => {
@@ -85,12 +85,11 @@ const CopyButton = ({ id }) => {
       {renderButton()}
       {user?.id && (
         <TreeModal
-          description={t(LIBRARY.COPY_BUTTON_MODAL_DESCRIPTION)}
           title={t(LIBRARY.COPY_BUTTON_MODAL_TITLE)}
           open={showTreeModal}
-          onConfirm={copy}
-          itemId={id}
           onClose={() => setShowTreeModal(false)}
+          onConfirm={copy}
+          itemIds={[id]}
         />
       )}
     </>

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -116,3 +116,5 @@ export const ENV = {
   PRODUCTION: 'production',
   TEST: 'test',
 };
+
+export const TREE_VIEW_MAX_WIDTH = 400;

--- a/src/config/selectors.js
+++ b/src/config/selectors.js
@@ -40,3 +40,9 @@ export const MY_LIKES_COLLECTIONS_ID = 'likedCollectionsGrid';
 export const MY_PUBLISHMENTS_COLLECTIONS_ID = 'publishmentCollectionsGrid';
 
 export const APP_NAVIGATION_DROP_DOWN_ID = 'appNavigationDropDown';
+
+export const COPY_MODAL_TITLE_ID = 'copyModalTitle';
+export const TREE_MODAL_MY_ITEMS_ID = 'treeModalMyItems';
+export const TREE_MODAL_SHARED_ITEMS_ID = 'treeModalSharedItems';
+export const TREE_MODAL_CONFIRM_BUTTON_ID = 'treeModalConfirmButton';
+export const buildTreeItemId = (id, treeRootId) => `${treeRootId}-${id}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1917,10 +1917,10 @@ __metadata:
 
 "@graasp/translations@github:graasp/graasp-translations.git":
   version: 0.1.0
-  resolution: "@graasp/translations@https://github.com/graasp/graasp-translations.git#commit=97252587d033d6ba804728107969851ef472c7ab"
+  resolution: "@graasp/translations@https://github.com/graasp/graasp-translations.git#commit=73ec2f6c2694a5c6b4aaa1b40bb80f07216fb918"
   dependencies:
     i18next: 21.8.1
-  checksum: 7c5e398ddab314d77c94fd7e1b6de11c5b383403e89492e40f428c752d580a388e694599a204a2f7e5a27e4eb5ee4aa510fdb11195b101a0988f0842034ef273
+  checksum: 0b55a3a2b1fda5864b33129e4849984c0c86400d679f56b3715a811b5a05fc5ac0a916bf09ee5a67bcc4994b2a62ebaeef1172f1e2120beb5b04a8c9f94095e1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
With the dynamic tree view, "my items" and "shared items" are expanded (first-level) by default

Closes #75 