### PR TITLE
chore: remove link to old graasp in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://graasp.eu/">
+  <a href="https://library.graasp.org/">
     <img alt="Graasp" src="https://avatars3.githubusercontent.com/u/43075056" width="300">
   </a>
 </p>


### PR DESCRIPTION
This PR updates the link under the graaps logo in the readme. 
It now redirects to the library site instead of the old graasp (graasp.eu)

closes #227 