### PR TITLE
fix: navigation using href

### DIFF
--- a/src/components/common/HeaderNavigation.tsx
+++ b/src/components/common/HeaderNavigation.tsx
@@ -47,8 +47,7 @@ export function defaultHostsMapper(
     [Platform.Player]: (origin: string, itemId: string) =>
       `${origin}/${itemId}`,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    [Platform.Library]: (origin: string, itemId: string) =>
-      origin,
+    [Platform.Library]: (origin: string, itemId: string) => origin,
     [Platform.Analytics]: (origin: string, itemId: string) =>
       `${origin}/${itemId}`,
   };

--- a/src/components/common/HeaderNavigation.tsx
+++ b/src/components/common/HeaderNavigation.tsx
@@ -5,8 +5,6 @@ import React from 'react';
 
 import { Box, Typography, styled } from '@mui/material';
 
-import { redirect } from '@graasp/sdk';
-
 import { APP_NAME, HOST_MAP } from '../../config/constants';
 import { HEADER_LOGO_HEIGHT } from '../../config/cssStyles';
 
@@ -77,13 +75,7 @@ export function usePlatformNavigation(
     const url = hostsMapper[platform]?.(itemId);
     const href = url ?? '#';
     return {
-      onClick: () => redirect(href),
-      onMouseDown: (event: React.MouseEvent) => {
-        if (event.button !== 1 || url === undefined) {
-          return;
-        }
-        window.open(href, '_blank');
-      },
+      href,
     };
   };
 }

--- a/src/components/common/HeaderNavigation.tsx
+++ b/src/components/common/HeaderNavigation.tsx
@@ -46,6 +46,7 @@ export function defaultHostsMapper(
       `${origin}/items/${itemId}`,
     [Platform.Player]: (origin: string, itemId: string) =>
       `${origin}/${itemId}`,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     [Platform.Library]: (origin: string, itemId: string) =>
       origin,
     [Platform.Analytics]: (origin: string, itemId: string) =>

--- a/src/components/common/HeaderNavigation.tsx
+++ b/src/components/common/HeaderNavigation.tsx
@@ -47,7 +47,7 @@ export function defaultHostsMapper(
     [Platform.Player]: (origin: string, itemId: string) =>
       `${origin}/${itemId}`,
     [Platform.Library]: (origin: string, itemId: string) =>
-      `${origin}/collections/${itemId}`,
+      origin,
     [Platform.Analytics]: (origin: string, itemId: string) =>
       `${origin}/${itemId}`,
   };


### PR DESCRIPTION
This PR fixes an issue with the navigation behavior changed in @graasp/ui@2.5.0.

Library still has its own copy of the navigation mechanism because of issues related to non-ssr-friendly bundling of @graasp/ui.

The navigation mechanism needed to be updated manually here. When we will be able to use graasp/ui directly this won't be necessary anymore.

Question: Should we also replicate the behavior of the library icon directing to the library Home ? @dialexo
