### PR TITLE
fix: get publication settings from item itself and not its top-level parent

### DIFF
--- a/cypress/e2e/collection/categories.cy.js
+++ b/cypress/e2e/collection/categories.cy.js
@@ -3,7 +3,6 @@ import { SUMMARY_CATEGORIES_CONTAINER_ID } from '../../../src/config/selectors';
 import { SAMPLE_CATEGORIES } from '../../fixtures/categories';
 import { buildPublicAndPrivateEnvironments } from '../../fixtures/environment';
 import { PUBLISHED_ITEMS } from '../../fixtures/items';
-import { COLLECTION_LOADING_TIME } from '../../support/constants';
 
 describe('Categories in Summary', () => {
   buildPublicAndPrivateEnvironments().forEach((environment) => {
@@ -27,23 +26,5 @@ describe('Categories in Summary', () => {
         });
       },
     );
-
-    it(`Child shows parent's categories ${environment.currentMember.name}`, () => {
-      cy.setUpApi(environment);
-
-      const item = PUBLISHED_ITEMS[0];
-
-      const child = PUBLISHED_ITEMS[1];
-
-      cy.visit(buildCollectionRoute(child.id));
-      cy.wait(COLLECTION_LOADING_TIME);
-
-      const categoryContainer = cy.get(`#${SUMMARY_CATEGORIES_CONTAINER_ID}`);
-
-      item.categories.forEach(({ categoryId }) => {
-        const category = SAMPLE_CATEGORIES.find(({ id }) => id === categoryId);
-        categoryContainer.should('contain', category?.name);
-      });
-    });
   });
 });

--- a/cypress/e2e/collection/summary.cy.js
+++ b/cypress/e2e/collection/summary.cy.js
@@ -7,7 +7,6 @@ import {
   CHILDREN_ITEMS_GRID_ID,
   ITEM_SUMMARY_TITLE_ID,
   SUMMARY_AUTHOR_CONTAINER_ID,
-  SUMMARY_CC_LICENSE_CONTAINER_ID,
   SUMMARY_CREATED_AT_CONTAINER_ID,
   SUMMARY_LAST_UPDATE_CONTAINER_ID,
   buildContributorId,
@@ -76,26 +75,6 @@ describe('Collection Summary', () => {
         cy.get(`#${buildContributorId(memberId)}`).should('exist');
       });
     });
-
-    it(
-      'CC license matches top level element',
-      { defaultCommandTimeout: 20000 },
-      () => {
-        cy.setUpApi(environment);
-
-        const parentItem = PUBLISHED_ITEMS[0];
-        const child = PUBLISHED_ITEMS[2];
-
-        if (parentItem.settings.ccLicenseAdaption && child !== undefined) {
-          cy.visit(buildCollectionRoute(child.id));
-
-          cy.get(`#${SUMMARY_CC_LICENSE_CONTAINER_ID}`).should(
-            'have.class',
-            parentItem.settings.ccLicenseAdaption,
-          );
-        }
-      },
-    );
 
     it('Hide co-editor', { defaultCommandTimeout: 10000 }, () => {
       cy.setUpApi(environment);

--- a/src/components/collection/Summary.tsx
+++ b/src/components/collection/Summary.tsx
@@ -84,14 +84,8 @@ const Summary: React.FC<SummaryProps> = ({
 
   const { hooks } = useContext(QueryClientContext);
 
-  const parents = getParentsIdsFromPath(path);
-
-  const { data: topLevelParent } = hooks.useItem(parents[0] ?? itemId);
-
   const { data: categoryTypes } = hooks.useCategoryTypes();
-  const { data: itemCategories } = hooks.useItemCategories(
-    topLevelParent?.id ?? itemId,
-  );
+  const { data: itemCategories } = hooks.useItemCategories(itemId);
   const { data: categories } = hooks.useCategories();
 
   const selectedCategories = categories
@@ -120,9 +114,7 @@ const Summary: React.FC<SummaryProps> = ({
     )?.id ?? '',
   );
 
-  const ccLicenseAdaption = topLevelParent
-    ? topLevelParent.settings?.ccLicenseAdaption
-    : settings?.ccLicenseAdaption;
+  const ccLicenseAdaption = settings?.ccLicenseAdaption as string | undefined;
 
   const { data: member } = hooks.useCurrentMember();
 


### PR DESCRIPTION
This behaviour is incorrect because the topmost parent may not be the published root.
Ideally we would want to fetch the published root, but this call is currently authenticated.
So meanwhile, we display the item publication settings of the current item, such that changes on published items which are not themselves top-level roots (i.e in my items) are still visible