### PR TITLE
feat: add a back button on the collection summary page

### DIFF
--- a/cypress/e2e/home/home.cy.ts
+++ b/cypress/e2e/home/home.cy.ts
@@ -28,10 +28,10 @@ describe('Home Page', () => {
 
         cy.get(`#${HOME_PAGE_TITLE_TEXT_ID}`)
           .should('be.visible')
-          .and('have.text', 'Graasp Library');
+          .and('have.text', i18n.t(LIBRARY.HOME_TITLE));
         cy.get(`#${POPULAR_THIS_WEEK_TITLE_ID} #${SECTION_TITLE_ID}`).should(
           'have.text',
-          i18n.t(LIBRARY.HOME_POPULAR_THIS_WEEK_COLLECTIONS_TITLE),
+          i18n.t(LIBRARY.HOME_RECENT_COLLECTIONS_TITLE),
         );
         cy.get(`#${MOST_LIKED_TITLE_ID} #${SECTION_TITLE_ID}`).should(
           'have.text',

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@emotion/styled": "11.11.0",
     "@graasp/query-client": "1.3.2",
     "@graasp/sdk": "1.1.3",
-    "@graasp/translations": "1.17.2",
+    "@graasp/translations": "1.18.1",
     "@graasp/ui": "3.2.6",
     "@mui/icons-material": "5.14.1",
     "@mui/lab": "5.0.0-alpha.137",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "postinstall": "husky install",
     "post-commit": "git status",
     "pre-commit": "yarn check",
-    "cypress:open": "env-cmd -f ./.env.test cypress open",
+    "cypress:open": "env-cmd -f ./.env.local cypress open",
     "cypress": "concurrently -k -s first \"yarn start:test\" \"wait-on http://localhost:3005 && yarn cypress:run\"",
     "cypress:run": "env-cmd -f ./.env.test cypress run --headless --browser chrome --spec \"cypress/**/*.(spec|cy).js\""
   },

--- a/src/components/collection/summary/Summary.tsx
+++ b/src/components/collection/summary/Summary.tsx
@@ -3,7 +3,7 @@ import truncate from 'lodash.truncate';
 import React, { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Typography } from '@mui/material';
+import { Stack, Typography } from '@mui/material';
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 
@@ -16,6 +16,7 @@ import {
   MAX_COLLECTION_NAME_LENGTH,
 } from '../../../config/constants';
 import { QueryClientContext } from '../../QueryClientContext';
+import BackButton from '../../common/BackButton';
 import ItemBreadcrumb from '../ItemBreadcrumb';
 import Items from '../Items';
 import SummaryDetails from './SummaryDetails';
@@ -77,22 +78,25 @@ const Summary: React.FC<SummaryProps> = ({
     ?.filter((c) => c.category.type === CategoryType.Language)
     .map((c) => c.category);
 
-  // todo: remove cast after refactor
-  const ccLicenseAdaption = (
-    topLevelParent
-      ? topLevelParent.settings?.ccLicenseAdaption
-      : collection?.settings?.ccLicenseAdaption
-  ) as string;
+  const ccLicenseAdaption = topLevelParent
+    ? topLevelParent.settings?.ccLicenseAdaption
+    : collection?.settings?.ccLicenseAdaption;
 
   const truncatedName = truncate(collection?.name, {
     length: MAX_COLLECTION_NAME_LENGTH,
     separator: /,? +/,
   });
   return (
-    <div>
-      <Container maxWidth="lg" sx={{ my: 2 }}>
-        <ItemBreadcrumb itemId={collection?.id} />
-      </Container>
+    <Stack
+      maxWidth="lg"
+      margin="auto"
+      alignItems="flex-start"
+      justifyItems="flex-start"
+      justifySelf="center"
+      spacing={2}
+    >
+      <BackButton />
+      <ItemBreadcrumb itemId={collection?.id} />
       <SummaryHeader
         collection={collection}
         isLogged={member?.id !== undefined}
@@ -129,7 +133,7 @@ const Summary: React.FC<SummaryProps> = ({
           levels={levels}
         />
       </Container>
-    </div>
+    </Stack>
   );
 };
 

--- a/src/components/common/BackButton.tsx
+++ b/src/components/common/BackButton.tsx
@@ -1,0 +1,19 @@
+import { useRouter } from 'next/router';
+
+import { ArrowBack } from '@mui/icons-material';
+import { Button } from '@mui/material';
+
+import { COMMON } from '@graasp/translations';
+
+import { useCommonTranslation } from '../../config/i18n';
+
+const BackButton = () => {
+  const { t } = useCommonTranslation();
+  const router = useRouter();
+  return (
+    <Button startIcon={<ArrowBack />} onClick={() => router.back()}>
+      {t(COMMON.BACK_BUTTON)}
+    </Button>
+  );
+};
+export default BackButton;

--- a/src/components/filters/FilterHeader.tsx
+++ b/src/components/filters/FilterHeader.tsx
@@ -84,7 +84,7 @@ const Filter: React.FC<FilterProps> = ({
     const optionsStr =
       options
         ?.filter((it) => selectedOptions.includes(it.id))
-        .map((it) => it.name)
+        .map((it) => t(it.name, { ns: namespaces.categories }))
         .get(0) ?? t(LIBRARY.FILTER_DROPDOWN_NO_FILTER);
     return optionsStr;
   }, [selectedOptions, options]);

--- a/src/components/layout/HomeHeader.tsx
+++ b/src/components/layout/HomeHeader.tsx
@@ -1,11 +1,14 @@
 import dynamic from 'next/dynamic';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 
 import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { ArrowForward } from '@mui/icons-material';
 import {
   Box,
+  Button,
   Chip,
   Container,
   Stack,
@@ -57,7 +60,7 @@ const HomeHeader = () => {
   const searchBarRef = useRef<HTMLDivElement>(null);
 
   // TODO: Feed from real data.
-  const popularSearches = ['Climate', 'Biology', 'Science', 'Education'];
+  const popularSearches = ['Climate', 'App', 'Science', 'Education'];
 
   const handleSearch = (searchKeywords: string) => {
     router.push({
@@ -107,20 +110,37 @@ const HomeHeader = () => {
             isLoading={false}
           />
         </Box>
-        <Box width="100%">
-          <Typography color="white" variant="h6" gutterBottom>
-            {t(LIBRARY.HOME_POPULAR_SEARCHES_TITLE)}
-          </Typography>
-          <Stack direction="row" spacing={2}>
-            {popularSearches.map((term) => (
-              <PopularSearchItem
-                key={term}
-                text={term}
-                onClick={handleSearch}
-              />
-            ))}
-          </Stack>
-        </Box>
+        <Stack
+          direction="row"
+          width="100%"
+          justifyContent="space-between"
+          alignItems="end"
+        >
+          <Box>
+            <Typography color="white" variant="h6" gutterBottom>
+              {t(LIBRARY.HOME_POPULAR_SEARCHES_TITLE)}
+            </Typography>
+            <Stack direction="row" spacing={2}>
+              {popularSearches.map((term) => (
+                <PopularSearchItem
+                  key={term}
+                  text={term}
+                  onClick={handleSearch}
+                />
+              ))}
+            </Stack>
+          </Box>
+          <Button
+            component={Link}
+            href={ALL_COLLECTIONS_ROUTE}
+            sx={{ textTransform: 'none' }}
+            color="secondary"
+            endIcon={<ArrowForward />}
+          >
+            {/* {todo: translate} */}
+            Browse All Collections
+          </Button>
+        </Stack>
       </Stack>
     </Container>
   );

--- a/src/components/layout/HomeHeader.tsx
+++ b/src/components/layout/HomeHeader.tsx
@@ -137,8 +137,7 @@ const HomeHeader = () => {
             color="secondary"
             endIcon={<ArrowForward />}
           >
-            {/* {todo: translate} */}
-            Browse All Collections
+            {t(LIBRARY.HOME_BROWSE_ALL_COLLECTIONS)}
           </Button>
         </Stack>
       </Stack>

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -10,7 +10,11 @@ import { Box, Button, styled } from '@mui/material';
 import { Context } from '@graasp/sdk';
 import { LIBRARY } from '@graasp/translations';
 
-import { APP_AUTHOR, GRAASP_COLOR } from '../../config/constants';
+import {
+  APP_AUTHOR,
+  GRAASP_COLOR,
+  HOMEPAGE_NB_ELEMENTS_TO_SHOW,
+} from '../../config/constants';
 import { NEXT_PUBLIC_GRAASPER_ID } from '../../config/env';
 import { ALL_COLLECTIONS_ROUTE } from '../../config/routes';
 import {
@@ -55,8 +59,12 @@ const Home = () => {
   const { data: graasperCollections } = hooks.usePublishedItemsForMember(
     NEXT_PUBLIC_GRAASPER_ID,
   );
-  const { data: mostLikedCollections } = hooks.useMostLikedPublishedItems();
-  const { data: recentCollections } = hooks.useMostRecentPublishedItems();
+  const { data: mostLikedCollections } = hooks.useMostLikedPublishedItems({
+    limit: HOMEPAGE_NB_ELEMENTS_TO_SHOW,
+  });
+  const { data: recentCollections } = hooks.useMostRecentPublishedItems({
+    limit: HOMEPAGE_NB_ELEMENTS_TO_SHOW,
+  });
 
   return (
     <StyledBackgroundContainer>
@@ -86,7 +94,7 @@ const Home = () => {
         <ItemCollection
           id={POPULAR_THIS_WEEK_TITLE_ID}
           collections={recentCollections}
-          title={t(LIBRARY.HOME_POPULAR_THIS_WEEK_COLLECTIONS_TITLE)}
+          title={t(LIBRARY.HOME_RECENT_COLLECTIONS_TITLE)}
         />
 
         <Box textAlign="center" marginBottom={20} marginTop={20}>

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -82,6 +82,8 @@ export const ENV = {
 
 export const TREE_VIEW_MAX_WIDTH = 400;
 
+export const HOMEPAGE_NB_ELEMENTS_TO_SHOW = 12;
+
 export const GRAASP_COLOR = '#5050D2';
 
 export const CATEGORY_COLORS: Record<

--- a/yarn.lock
+++ b/yarn.lock
@@ -1651,12 +1651,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/translations@npm:1.17.2":
-  version: 1.17.2
-  resolution: "@graasp/translations@npm:1.17.2"
+"@graasp/translations@npm:1.18.1":
+  version: 1.18.1
+  resolution: "@graasp/translations@npm:1.18.1"
   dependencies:
     i18next: 22.4.15
-  checksum: c5d711c95af9d225eff343a84da5099dc10cb243d78796d5f4daa7a3941d564770a3a9b84f55d3e7b2f95894033245912326928127824cda0611de35ccf30bbe
+  checksum: 84ca62be4646649469df867dcf9ab9dc8f8ad11eb3b4720d434eb63d544e15f3cd89cb971170b73703324780b4277ed8fe6e89a948ae6e1672173726a0d24ad5
   languageName: node
   linkType: hard
 
@@ -7020,7 +7020,7 @@ __metadata:
     "@emotion/styled": 11.11.0
     "@graasp/query-client": 1.3.2
     "@graasp/sdk": 1.1.3
-    "@graasp/translations": 1.17.2
+    "@graasp/translations": 1.18.1
     "@graasp/ui": 3.2.6
     "@mui/icons-material": 5.14.1
     "@mui/lab": 5.0.0-alpha.137


### PR DESCRIPTION
In this PR we:
- add a "Back" button on the collections summary page
- add a button to brows all collections in the home page header
- limits the number of pulled collections to 12 per section on the home page 
- #332 

close #332
close #336 

<img width="1468" alt="Screenshot 2023-08-08 at 22 29 10" src="https://github.com/graasp/graasp-library/assets/39373170/cee36dab-5d24-489a-abcd-dedb00440db0">
<img width="858" alt="Screenshot 2023-08-08 at 22 29 46" src="https://github.com/graasp/graasp-library/assets/39373170/6df06eda-dc6c-4976-b0b5-224567bf5c93">
