### PR TITLE
fix: only show like button to logged-in users

### DIFF
--- a/cypress/e2e/collection/summary.cy.ts
+++ b/cypress/e2e/collection/summary.cy.ts
@@ -83,6 +83,18 @@ describe('Collection Summary', () => {
       });
     });
 
+    it('Show like button only to logged in users', () => {
+      cy.setUpApi(environment);
+      const item = PUBLISHED_ITEMS[1];
+      cy.visit(buildCollectionRoute(item.id));
+
+      if (environment.currentMember) {
+        cy.get(`button[aria-label="like"]`).should('be.visible');
+      } else {
+        cy.get(`button[aria-label="like"]`).should('not.exist');
+      }
+    });
+
     it('Hide co-editor', { defaultCommandTimeout: 10000 }, () => {
       cy.setUpApi(environment);
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -45,10 +45,6 @@ Cypress.Commands.add(
   } = {}) => {
     const cachedMembers = JSON.parse(JSON.stringify(members));
 
-    if (currentMember?.id) {
-      cy.setCookie('session', currentMember?.id);
-    }
-
     mockGetAllPublishedItems({ items }, getPublishedItemsInCategoriesError);
 
     mockGetOwnItems({ items, currentMember });

--- a/src/components/collection/CopyButton.tsx
+++ b/src/components/collection/CopyButton.tsx
@@ -91,7 +91,7 @@ const CopyButton = ({ id }: Props) => {
     }
 
     return (
-      <Tooltip title={t(LIBRARY.COPY_BUTTON_TOOLTIP)} placement="top">
+      <Tooltip title={t(LIBRARY.COPY_BUTTON_TOOLTIP)}>
         <IconButton
           onClick={startCopy}
           aria-label={t(LIBRARY.COPY_BUTTON_TOOLTIP)}

--- a/src/components/collection/CopyLinkButton.tsx
+++ b/src/components/collection/CopyLinkButton.tsx
@@ -62,7 +62,7 @@ const CopyLinkButton = ({ item }: CopyLinkButtonProps) => {
   const { startEmbed } = useEmbedAction(item);
 
   return (
-    <Tooltip title={t(LIBRARY.COPY_LINK_BUTTON_TOOLTIP)} placement="top">
+    <Tooltip title={t(LIBRARY.COPY_LINK_BUTTON_TOOLTIP)}>
       <IconButton
         onClick={startEmbed}
         aria-label={t(LIBRARY.COPY_LINK_BUTTON_TOOLTIP)}

--- a/src/components/collection/summary/SummaryHeader.tsx
+++ b/src/components/collection/summary/SummaryHeader.tsx
@@ -137,13 +137,15 @@ const SummaryHeader: React.FC<SummaryHeaderProps> = ({
               >
                 {truncatedName}
               </Typography>
-              <LikeButton
-                ariaLabel="like"
-                color="primary"
-                isLiked={Boolean(likeEntry)}
-                handleLike={handleLike}
-                handleUnlike={handleUnlike}
-              />
+              {member && member.id && (
+                <LikeButton
+                  ariaLabel="like"
+                  color="primary"
+                  isLiked={Boolean(likeEntry)}
+                  handleLike={handleLike}
+                  handleUnlike={handleUnlike}
+                />
+              )}
             </Stack>
             <SummaryActionButtons item={collection} isLogged={isLogged} />
           </Stack>


### PR DESCRIPTION
In this PR we fix:
- only show like button to logged in users

Logged out users will not see the like button.

closes #347
