### PR TITLE
fix(ui): small color and wrapping improvements

### DIFF
--- a/src/components/layout/HomeHeader.tsx
+++ b/src/components/layout/HomeHeader.tsx
@@ -47,6 +47,9 @@ const PopularSearchItem = ({
       sx={{
         color: theme.palette.primary.contrastText,
         borderColor: theme.palette.primary.contrastText,
+        ':hover': {
+          backgroundColor: 'rgba(0, 0, 0, 0.2)',
+        },
       }}
       label={text}
       onClick={() => onClick(text)}
@@ -120,7 +123,13 @@ const HomeHeader = () => {
             <Typography color="white" variant="h6" gutterBottom>
               {t(LIBRARY.HOME_POPULAR_SEARCHES_TITLE)}
             </Typography>
-            <Stack direction="row" spacing={2}>
+            <Stack
+              direction="row"
+              columnGap={2}
+              rowGap={1}
+              flexWrap="wrap"
+              useFlexGap
+            >
               {popularSearches.map((term) => (
                 <PopularSearchItem
                   key={term}
@@ -133,7 +142,12 @@ const HomeHeader = () => {
           <Button
             component={Link}
             href={ALL_COLLECTIONS_ROUTE}
-            sx={{ textTransform: 'none' }}
+            sx={{
+              textTransform: 'none',
+              ':hover': {
+                backgroundColor: 'rgba(255, 255, 255, 0.15)',
+              },
+            }}
             color="secondary"
             endIcon={<ArrowForward />}
           >

--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -61,7 +61,7 @@ const Search = forwardRef<HTMLDivElement, SearchProps>(function Search(
         my: 1,
         borderRadius: 2,
         border: '1px solid transparent',
-        transition: 'border-color 0.1s ease-in',
+        transition: 'all 0.3s ease-in-out',
         '&:hover, &:has(.Mui-focused)': {
           border: '1px solid #5050d230',
           boxShadow: '0px 0px 30px 2px #5050d230',

--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -60,6 +60,12 @@ const Search = forwardRef<HTMLDivElement, SearchProps>(function Search(
         width: '100%',
         my: 1,
         borderRadius: 2,
+        border: '1px solid transparent',
+        transition: 'border-color 0.1s ease-in',
+        '&:hover, &:has(.Mui-focused)': {
+          border: '1px solid #5050d230',
+          boxShadow: '0px 0px 30px 2px #5050d230',
+        },
       }}
       ref={ref}
     >


### PR DESCRIPTION
This PR:
- increases the background color on hover of:
  - popular searches chips
  - go to all collections shortcut button
- wrap popular searches chips to better fit smaller screens
- adds a small glow effect on the search bar when hovered or focused

Background changes (old on the left, new on the right):
<img width="1651" alt="Screenshot 2023-08-14 at 12 39 16" src="https://github.com/graasp/graasp-library/assets/39373170/00829812-951d-4661-a577-d6e72666e04a">
The keyword "Science" and the button are in forced hover state (for demo purposes).

Glow effect:

https://github.com/graasp/graasp-library/assets/39373170/d7d86a0d-163f-4804-a28e-b63084e86775


