### PR TITLE
fix: remove copy button from library as currently broken

### DIFF
--- a/src/components/collection/ChildrenCard.tsx
+++ b/src/components/collection/ChildrenCard.tsx
@@ -26,7 +26,6 @@ import { useLibraryTranslation } from '../../config/i18n';
 import { buildCollectionRoute } from '../../config/routes';
 import LIBRARY from '../../langs/constants';
 import { QueryClientContext } from '../QueryClientContext';
-import CopyButton from './CopyButton';
 import CopyLinkButton from './CopyLinkButton';
 import DownloadButton from './DownloadButton';
 
@@ -74,9 +73,9 @@ export const SubItemCard: React.FC<SubItemCardProps> = ({
   thumbnail,
   subtext,
 }) => {
-  const { hooks } = useContext(QueryClientContext);
+  // const { hooks } = useContext(QueryClientContext);
 
-  const { data: member } = hooks.useCurrentMember();
+  // const { data: member } = hooks.useCurrentMember();
 
   const { name, id } = item;
 
@@ -88,7 +87,7 @@ export const SubItemCard: React.FC<SubItemCardProps> = ({
       href={link}
       actions={
         <>
-          {member?.id && <CopyButton id={id} />}
+          {/* {member?.id && <CopyButton id={id} />} */}
           <CopyLinkButton itemId={item.id} />
           <DownloadButton id={id} />
         </>

--- a/src/components/collection/CollectionCard.tsx
+++ b/src/components/collection/CollectionCard.tsx
@@ -25,7 +25,6 @@ import { QueryClientContext } from '../QueryClientContext';
 import CardMediaComponent from '../common/CardMediaComponent';
 import { StyledCard } from '../common/StyledCard';
 import ContentDescription from './ContentDescription';
-import CopyButton from './CopyButton';
 import CopyLinkButton from './CopyLinkButton';
 import DownloadButton from './DownloadButton';
 
@@ -118,7 +117,7 @@ export const CollectionCard = ({ collection, showIsContentTag }: Props) => {
   } = collection;
   const { t } = useLibraryTranslation();
   const { hooks } = useContext(QueryClientContext);
-  const { data: member } = hooks.useCurrentMember();
+  // const { data: member } = hooks.useCurrentMember();
   const { data: authorAvatarUrl, isLoading: isLoadingAvatar } =
     hooks.useAvatarUrl({
       id: creator?.id,
@@ -205,7 +204,7 @@ export const CollectionCard = ({ collection, showIsContentTag }: Props) => {
         </Stack>
         <Box>
           <DownloadButton id={id} />
-          {member?.id && <CopyButton id={id} />}
+          {/* {member?.id && <CopyButton id={id} />} */}
           <CopyLinkButton itemId={collection.id} />
         </Box>
       </CardActions>

--- a/src/components/collection/summary/SummaryActionButtons.tsx
+++ b/src/components/collection/summary/SummaryActionButtons.tsx
@@ -1,11 +1,10 @@
 import React, { useState } from 'react';
 
-import { Code, CopyAll, Download, MoreVert } from '@mui/icons-material';
+import { Code, Download, MoreVert } from '@mui/icons-material';
 import PlayCircleOutlineIcon from '@mui/icons-material/PlayCircleOutline';
 import {
   Button,
   ButtonGroup,
-  CircularProgress,
   ClickAwayListener,
   Grow,
   Popper,
@@ -34,11 +33,10 @@ type SummaryActionButtonsProps = {
 
 const SummaryActionButtons: React.FC<SummaryActionButtonsProps> = ({
   item,
-  isLogged,
 }) => {
   const { t } = useLibraryTranslation();
 
-  const { isCopying, startCopy, treeModal } = useCopyAction(item?.id);
+  const { treeModal } = useCopyAction(item?.id);
 
   const { startDownload } = useDownloadAction(item?.id);
 
@@ -127,7 +125,7 @@ const SummaryActionButtons: React.FC<SummaryActionButtonsProps> = ({
                   >
                     {t(LIBRARY.SUMMARY_ACTIONS_DOWNLOAD)}
                   </StyledButton>
-                  {isLogged && (
+                  {/* {isLogged && (
                     <StyledButton
                       color="secondary"
                       onClick={startCopy}
@@ -145,7 +143,7 @@ const SummaryActionButtons: React.FC<SummaryActionButtonsProps> = ({
                     >
                       {t(LIBRARY.SUMMARY_ACTIONS_COPY)}
                     </StyledButton>
-                  )}
+                  )} */}
                   <StyledButton
                     color="secondary"
                     onClick={startEmbed}


### PR DESCRIPTION
In this PR I remove the copy button. It is currently broken since it uses the old TreeModal.

A more permanent fix would be to port the new treeModal to the library.
ref #602 