### PR TITLE
fix: align for mobile title, like button and preview button

### DIFF
--- a/src/components/collection/summary/SummaryHeader.tsx
+++ b/src/components/collection/summary/SummaryHeader.tsx
@@ -152,29 +152,30 @@ export function SummaryHeader({
       <Stack direction="column" spacing={1} width={{ xs: '90%', sm: '70%' }}>
         <Stack
           justifyContent="space-between"
-          direction="row"
           flexWrap="wrap"
+          direction={{ xs: 'column', sm: 'row' }}
+          gap={{ xs: 0, sm: 1 }}
           alignItems={{ xs: 'start', sm: 'start' }}
         >
           <Stack
             direction="row"
-            alignItems="center"
             spacing={1}
             minWidth={0}
+            width="100%"
             flex={1}
+            justifyContent="space-between"
           >
             <Typography
               variant="h3"
               component="h1"
               sx={{ wordBreak: 'break-word' }}
+              // to match icon height
+              lineHeight="2.5rem"
               id={ITEM_SUMMARY_TITLE_ID}
-              // allow to see full text on mouse hover
               title={collection.name}
             >
               {collection.name}
             </Typography>
-          </Stack>
-          <Stack direction="row" gap={1}>
             <LikeButton
               ariaLabel="like"
               color="primary"
@@ -182,6 +183,13 @@ export function SummaryHeader({
               handleLike={handleLike}
               handleUnlike={handleUnlike}
             />
+          </Stack>
+          <Stack
+            direction="row"
+            width={{ xs: '100%', sm: 'auto' }}
+            justifyContent={{ xs: 'center', sm: 'flex-start' }}
+            my={{ xs: 2, sm: 0 }}
+          >
             <SummaryActionButtons item={collection} isLogged={isLogged} />
           </Stack>
         </Stack>


### PR DESCRIPTION
Align title, like button and preview button for mobiles.

fix #847 

<img width="322" height="669" alt="Screenshot 2025-10-28 at 15 37 35" src="https://github.com/user-attachments/assets/b6c0fe73-f39d-4235-b02b-6da82c22b441" />
<img width="763" height="387" alt="Screenshot 2025-10-28 at 15 36 57" src="https://github.com/user-attachments/assets/8dc2dba5-048b-42e5-970b-1c8d7bd5de85" />
<img width="762" height="380" alt="Screenshot 2025-10-28 at 15 36 35" src="https://github.com/user-attachments/assets/d001cc61-04ce-4386-8d28-6d0c7f61c355" />
<img width="320" height="629" alt="Screenshot 2025-10-28 at 15 36 13" src="https://github.com/user-attachments/assets/a6580d1f-ce1c-4bec-8480-8e5894076860" />
